### PR TITLE
Implement caching and stepwise term lookup

### DIFF
--- a/cache.py
+++ b/cache.py
@@ -1,0 +1,23 @@
+import json
+import os
+from typing import Dict
+
+CACHE_FILE = os.path.join(os.path.expanduser("~"), ".language_helper_cache.json")
+
+
+def load_cache() -> Dict:
+    if not os.path.exists(CACHE_FILE):
+        return {}
+    try:
+        with open(CACHE_FILE, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except Exception:
+        return {}
+
+
+def save_cache(cache: Dict) -> None:
+    try:
+        with open(CACHE_FILE, "w", encoding="utf-8") as f:
+            json.dump(cache, f)
+    except Exception:
+        pass

--- a/prompts.py
+++ b/prompts.py
@@ -1,24 +1,41 @@
 class PromptFactory:
     def create_prompt(self, target_lang: str) -> str:
+        """Prompt for explaining given terms."""
+        raise NotImplementedError
+
+    def create_identify_prompt(self, target_lang: str) -> str:
+        """Prompt for extracting terms from an image."""
         raise NotImplementedError
 
 
 class EnglishPromptFactory(PromptFactory):
     def create_prompt(self, target_lang: str) -> str:
         return (
-            "You are a language tutor. Analyze the text in the image for learners of "
-            f"{target_lang}. Return explanations in English following the provided schema. "
-            "Include sections for every level (N1-N5) even if they contain no items."
+            "You are a language tutor. Provide detailed explanations in English "
+            "for the given "
+            f"{target_lang} vocabulary and grammar following the provided schema."
+        )
+
+    def create_identify_prompt(self, target_lang: str) -> str:
+        return (
+            "You are a language tutor. Analyze the text in the image and list all "
+            f"{target_lang} vocabulary words and grammar points. Group them by JLPT "
+            "level N1 to N5 following the provided schema."
         )
 
 
 class ChinesePromptFactory(PromptFactory):
     def create_prompt(self, target_lang: str) -> str:
         return (
-            f"請分析圖片中的{target_lang}文字，依照給定的結構列出詞彙與文法，以繁體中文回答。" 
-            "請回傳N1到N5每一級的資料，即便沒有內容也要給空陣列。"
+            f"請根據提供的{target_lang}單字與文法，以繁體中文輸出詳盡說明，並遵守結構。"
+        )
+
+    def create_identify_prompt(self, target_lang: str) -> str:
+        return (
+            f"請分析圖片中的{target_lang}文字，僅列出出現的單字與文法，依JLPT N1到N5分類，照結構回傳。"
         )
 
 
 def get_prompt_factory(language: str) -> PromptFactory:
     return ChinesePromptFactory() if language.startswith("zh") else EnglishPromptFactory()
+

--- a/schema.py
+++ b/schema.py
@@ -1,3 +1,13 @@
+NAME_LIST_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "vocabulary": {"type": "array", "items": {"type": "string"}},
+        "grammar": {"type": "array", "items": {"type": "string"}},
+    },
+    "required": ["vocabulary", "grammar"],
+}
+
+
 ITEM_SCHEMA = {
     "type": "object",
     "properties": {
@@ -169,6 +179,20 @@ RESPONSE_SCHEMA = {
         "N3": ITEM_SCHEMA,
         "N4": ITEM_SCHEMA,
         "N5": ITEM_SCHEMA,
+    },
+    "required": ["N1", "N2", "N3", "N4", "N5"],
+    "additionalProperties": False,
+}
+
+
+IDENTIFY_RESPONSE_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "N1": {"anyOf": [NAME_LIST_SCHEMA, {"type": "null"}]},
+        "N2": {"anyOf": [NAME_LIST_SCHEMA, {"type": "null"}]},
+        "N3": {"anyOf": [NAME_LIST_SCHEMA, {"type": "null"}]},
+        "N4": {"anyOf": [NAME_LIST_SCHEMA, {"type": "null"}]},
+        "N5": {"anyOf": [NAME_LIST_SCHEMA, {"type": "null"}]},
     },
     "required": ["N1", "N2", "N3", "N4", "N5"],
     "additionalProperties": False,


### PR DESCRIPTION
## Summary
- introduce simple JSON cache for vocabulary and grammar
- extend prompt factory with identify/explain prompts
- define schemas for term identification responses
- rework OpenAI client to detect terms, look up cache, request missing details and store them

## Testing
- `python -m py_compile cache.py prompts.py openai_client.py schema.py ui.py main.py config.py`

------
https://chatgpt.com/codex/tasks/task_e_68608b4f212c8325bec847cbdf16da62