### PR TITLE
Improve vocabulary markdown format and shrink options panel

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -72,7 +72,7 @@ class MainWindow(QtWidgets.QWidget):
         layout = QtWidgets.QHBoxLayout()
 
         self.display_area = DisplayArea()
-        layout.addWidget(self.display_area, 2)
+        layout.addWidget(self.display_area, 11)
 
         right_layout = QtWidgets.QVBoxLayout()
         form = QtWidgets.QFormLayout()


### PR DESCRIPTION
## Summary
- narrow option panel to 1/12 of the window width
- split vocabulary markdown generation from grammar and implement new format

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686917bda77c83258a981550b25e90b6